### PR TITLE
use keycloak query redirect; add backend binding via get_user

### DIFF
--- a/client.py
+++ b/client.py
@@ -65,11 +65,13 @@ async def get_user(request):
     '''
     TODO: implement backend.
     should take access token from request cookies and return user info from its DB like this:
-    >>> token = request.cookies.get('access')
-    >>> data = parse_jwt(token)
-    >>> user_info = get_user_from_db(data['name'])
+    >>> web.get("/user/{name}", get_user),
+    ...
+    >>> name = request.match_info['name']
+    >>> return web.json_response(get_user_from_db(name))
     '''
-    url = BACKEND_URL + 'get_user'
+    name = request.match_info['name']
+    url = BACKEND_URL + 'user/' + name
     async with ClientSession(cookies=request.cookies) as session:
         async with session.get(url) as resp:
             # TODO: change to json once endpoint is ready

--- a/client.py
+++ b/client.py
@@ -61,28 +61,10 @@ async def request_token(request):
     return response
 
 
-async def get_user(request):
-    '''
-    TODO: implement backend.
-    should take access token from request cookies and return user info from its DB like this:
-    >>> web.get("/user/{name}", get_user),
-    ...
-    >>> name = request.match_info['name']
-    >>> return web.json_response(get_user_from_db(name))
-    '''
-    name = request.match_info['name']
-    url = BACKEND_URL + 'user/' + name
-    async with ClientSession(cookies=request.cookies) as session:
-        async with session.get(url) as resp:
-            # TODO: change to json once endpoint is ready
-            data = await resp.text()
-    return web.Response(text=data)
-
-
 async def index(request):
     # if code is set in GET params, it was made by keycloak redirect after auth
     code = request.rel_url.query.get('code')
     response = aiohttp_jinja2.render_template(
-        "login.html", request, context={'keycloak_code': code})
+        "login.html", request, context={'keycloak_code': code, 'backend_url': BACKEND_URL})
 
     return response

--- a/client.py
+++ b/client.py
@@ -4,17 +4,19 @@ from urllib.parse import parse_qs
 from aiohttp import web, ClientSession
 import aiohttp_jinja2
 
-from settings import KEYCLOAK_URL, KEYCLOAK_REDIRECT_URL, KEYCLOAK_CLIENT
+from settings import KEYCLOAK_URL, KEYCLOAK_REDIRECT_URL, KEYCLOAK_CLIENT, BACKEND_URL
 
 
 async def login(request):
+    '''redirects to keycloak login url'''
     url = KEYCLOAK_URL + "auth"
-    response_mode = 'fragment'  # sets code to URL fragment. form_post does POST
+    response_mode = 'query'  # 'fragment' sets code to URL fragment, 'form_post' does POST, 'query' does GET
     url += f'?client_id={KEYCLOAK_CLIENT}&redirect_uri={KEYCLOAK_REDIRECT_URL}&response_mode={response_mode}&response_type=code&scope=openid'
     return web.HTTPFound(url)
 
 
 async def logout(request):
+    '''redirects to keycloak logout url and removes jwt from cookies'''
     url = KEYCLOAK_URL + "logout"
     url += f'?client_id={KEYCLOAK_CLIENT}&post_logout_redirect_uri={KEYCLOAK_REDIRECT_URL}'
     response = web.HTTPFound(url)
@@ -25,31 +27,60 @@ async def logout(request):
 # refresh:
 # https://stackoverflow.com/questions/51386337/refresh-access-token-via-refresh-token-in-keycloak
 
-async def request_token(request):
-    params = await request.text()
-    data = parse_qs(urlparse('?' + params).query)
-    code = data['code'][0]
-    print(f"request token for {code}")
-
+# TODO: move from client to backend?
+async def keycloak_request_token(code):
+    '''retrieves JWT from keycloak server by code'''
     url = KEYCLOAK_URL + "token"
     body = f"code={code}&grant_type=authorization_code&client_id={KEYCLOAK_CLIENT}&redirect_uri={KEYCLOAK_REDIRECT_URL}"
     headers = {"Content-type": "application/x-www-form-urlencoded"}
     async with ClientSession(headers=headers) as session:
         async with session.post(url, data=bytes(body.encode())) as resp:
-            data = await resp.json()
+            return await resp.json()
+
+
+async def request_token(request):
+    '''sets access/refresh tokens to cookies and redirects to /'''
+    # html POST form can't send json, so parsing params as query string
+    params = await request.text()
+    data = parse_qs(urlparse('?' + params).query)
+    code = data['code'][0]
+
     response = web.HTTPFound('/')
-    # available keys:
-    # dict_keys(['access_token', 'expires_in', 'refresh_expires_in', 'refresh_token', 'token_type', 'id_token', 'not-before-policy', 'session_state', 'scope'])
-    if 'error' in data:
-        print(data)
+
+    token = await keycloak_request_token(code)
+    if not token or 'error' in token:
         response.del_cookie('access')
+        print(code, token)
     else:
-        response.cookies['access'] = data.get('access_token')
-        response.cookies['refresh'] = data.get('refresh_token')
+        # available keys in token:
+        # dict_keys(['access_token', 'expires_in', 'refresh_expires_in', 'refresh_token',
+        # 'token_type', 'id_token', 'not-before-policy', 'session_state', 'scope'])
+        response.cookies['access'] = token.get('access_token')
+        response.cookies['refresh'] = token.get('refresh_token')
+
     return response
 
 
+async def get_user(request):
+    '''
+    TODO: implement backend.
+    should take access token from request cookies and return user info from its DB like this:
+    >>> token = request.cookies.get('access')
+    >>> data = parse_jwt(token)
+    >>> user_info = get_user_from_db(data['name'])
+    '''
+    url = BACKEND_URL + 'get_user'
+    async with ClientSession(cookies=request.cookies) as session:
+        async with session.get(url) as resp:
+            # TODO: change to json once endpoint is ready
+            data = await resp.text()
+    return web.Response(text=data)
+
+
 async def index(request):
+    # if code is set in GET params, it was made by keycloak redirect after auth
+    code = request.rel_url.query.get('code')
     response = aiohttp_jinja2.render_template(
-        "login.html", request, context={})
+        "login.html", request, context={'keycloak_code': code})
+
     return response

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from aiohttp import web
 import jinja2
 import aiohttp_jinja2
 
-from client import index, login, logout, request_token
+from client import index, login, logout, get_user, request_token
 from settings import PORT
 
 app = web.Application()
@@ -16,6 +16,7 @@ app.add_routes([
     web.get("/", index),
     web.get("/login", login),
     web.get("/logout", logout),
+    web.get("/get_user", get_user),
     web.post("/request_token", request_token),
     web.static('/static', 'static'),
 ])

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from aiohttp import web
 import jinja2
 import aiohttp_jinja2
 
-from client import index, login, logout, get_user, request_token
+from client import index, login, logout, request_token
 from settings import PORT
 
 app = web.Application()
@@ -16,7 +16,6 @@ app.add_routes([
     web.get("/", index),
     web.get("/login", login),
     web.get("/logout", logout),
-    web.get("/user/{name}", get_user),
     web.post("/request_token", request_token),
     web.static('/static', 'static'),
 ])

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ app.add_routes([
     web.get("/", index),
     web.get("/login", login),
     web.get("/logout", logout),
-    web.get("/get_user", get_user),
+    web.get("/user/{name}", get_user),
     web.post("/request_token", request_token),
     web.static('/static', 'static'),
 ])

--- a/settings.py
+++ b/settings.py
@@ -5,7 +5,7 @@ KEYCLOAK_REDIRECT_URL = "http://0.0.0.0:8080/"
 KEYCLOAK_CLIENT = "fake-client"
 KEYCLOAK_URL = f"https://keycloak.regela.ru/realms/{KEYCLOAK_REALM}/protocol/openid-connect/"
 
-BACKEND_URL = "http://0.0.0.0:8888/"
+BACKEND_URL = "http://0.0.0.0:8888"
 
 
 # for locally rewrite settings add it to settings_local.py

--- a/settings.py
+++ b/settings.py
@@ -5,6 +5,8 @@ KEYCLOAK_REDIRECT_URL = "http://0.0.0.0:8080/"
 KEYCLOAK_CLIENT = "fake-client"
 KEYCLOAK_URL = f"https://keycloak.regela.ru/realms/{KEYCLOAK_REALM}/protocol/openid-connect/"
 
+BACKEND_URL = "http://0.0.0.0:8888/"
+
 
 # for locally rewrite settings add it to settings_local.py
 try:

--- a/templates/login.html
+++ b/templates/login.html
@@ -21,7 +21,7 @@
     <input type="submit" value="Log out" />
   </form>
 
-  <a id=user_info_link target=_blank href=/get_user>View user info - opens JSON in new tab</a>
+  <a id=user_info_link target=_blank href='/user/%username%'>View user info - opens JSON in new tab</a>
 {% endblock %}
 
 {% block script %}
@@ -53,6 +53,8 @@ if (access) {
     document.body.appendChild(p);
     console.debug(parsed_access)
     document.getElementById('login').remove()
+    let user_link = document.getElementById('user_info_link')
+    user_link.href = user_link.href.replace('%username%', parsed_access.preferred_username)
     // добавить refresh?
 }
 else {

--- a/templates/login.html
+++ b/templates/login.html
@@ -21,7 +21,7 @@
     <input type="submit" value="Log out" />
   </form>
 
-  <a id=user_info_link target=_blank href='/user/%username%'>View user info - opens JSON in new tab</a>
+  <a id=user_info_link target=_blank href='{{backend_url}}/user/%username%'>View user info - opens JSON in new tab</a>
 {% endblock %}
 
 {% block script %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,36 +1,31 @@
 {% extends 'base.html' %}
 
 {% block content %}
+
+  {% if keycloak_code %}
+
+  <form id=request_token action="/request_token" method=post>
+    <input type="hidden" name=code value="{{ keycloak_code }}" />
+    <input type="submit" value="Request token - will set JWT to cookies" />
+  </form>
+
+  {% else %}
+
   <form id=login action="/login">
     <input type="submit" value="Log in" />
   </form>
+
+  {% endif %}
 
   <form id=logout action="/logout">
     <input type="submit" value="Log out" />
   </form>
 
-  <form id=request_token action="/request_token" method=post>
-    <input type="submit" value="Request token" />
-  </form>
+  <a id=user_info_link target=_blank href=/get_user>View user info - opens JSON in new tab</a>
 {% endblock %}
 
 {% block script %}
 <script>
-function getHashParams() {
-
-    var hashParams = {};
-    var e,
-        a = /\+/g,  // Regex for replacing addition symbol with a space
-        r = /([^&;=]+)=?([^&;]*)/g,
-        d = function (s) { return decodeURIComponent(s.replace(a, " ")); },
-        q = window.location.hash.substring(1);
-
-    while (e = r.exec(q))
-       hashParams[d(e[1])] = d(e[2]);
-
-    return hashParams;
-}
-
 function parseJwt (token) {
     var base64Url = token.split('.')[1];
     var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
@@ -49,24 +44,7 @@ function getCookie(name) {
 
 
 let access = getCookie('access');
-if (window.location.hash) {
-    let textNode = document.createTextNode('user logged in, keycloak returned ' + JSON.stringify(getHashParams()));
-    let p = document.createElement("p");
-    p.appendChild(textNode);
-    document.body.appendChild(p);
-
-    var form = document.getElementById('request_token');
-    form.addEventListener('submit', function(){
-        var hidden = document.createElement("input");
-        hidden.setAttribute('type', 'hidden');
-        hidden.setAttribute('name', 'code');
-        hidden.setAttribute('value', getHashParams().code);
-        this.appendChild(hidden);
-    });
-    document.getElementById('login').remove()
-}
-
-else if (access) {
+if (access) {
     let parsed_access = parseJwt(access);
     let username = parsed_access.name;
     let textNode = document.createTextNode('Hello ' + username + '! You can check debug info about your access token in dev console');
@@ -75,12 +53,10 @@ else if (access) {
     document.body.appendChild(p);
     console.debug(parsed_access)
     document.getElementById('login').remove()
-    document.getElementById('request_token').remove()
     // добавить refresh?
 }
 else {
-    document.getElementById('request_token').remove()
-    document.getElementById('logout').remove()
+    document.getElementById('user_info_link').remove()
 }
 
 </script>


### PR DESCRIPTION
немного изменён интерфейс, уменьшено количество жаваскрипта. 
![1 1](https://github.com/openworld-community/passport-client/assets/18052024/8d5c27aa-b2f8-4dae-b738-98e600ee40e2)

после логина и запроса токена внизу добавится ссылка чтоб потыкать интеграцию с бэком
![1 2](https://github.com/openworld-community/passport-client/assets/18052024/8a75284b-9051-4a84-8da5-0857cb3d3685)

желаемый формат эндпоинта на бэке описан в докстринге клиента 
